### PR TITLE
link usb library to certain files, and update how some search for executables 

### DIFF
--- a/ros/src/CMakeLists.txt
+++ b/ros/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-/opt/anaconda3/envs/ros_noetic/share/catkin/cmake/toplevel.cmake
+/opt/ros/noetic/share/catkin/cmake/toplevel.cmake

--- a/ros/src/crazyflie_control_merger/CMakeLists.txt
+++ b/ros/src/crazyflie_control_merger/CMakeLists.txt
@@ -7,7 +7,7 @@ project(crazyflie_control_merger)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 #endif()
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/crazyflie_control_merger/modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/modules)  
 message("Cmake module path: ${CMAKE_MODULE_PATH}")
 
 find_package(Eigen3 REQUIRED)
@@ -57,7 +57,7 @@ link_directories(
   ${EIGEN3_LIBRARY_DIRS}
 )
 
-file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/src/*.cpp)
+file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${PROJECT_SOURCE_DIR}/src/*.cpp)
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_srcs})
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 

--- a/ros/src/crazyflie_lqr/CMakeLists.txt
+++ b/ros/src/crazyflie_lqr/CMakeLists.txt
@@ -7,7 +7,7 @@ project(crazyflie_lqr)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 #endif()
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/crazyflie_lqr/modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/modules)
 message("Cmake module path: ${CMAKE_MODULE_PATH}")
 
 find_package(Eigen3 REQUIRED)
@@ -55,7 +55,7 @@ link_directories(
   ${EIGEN3_LIBRARY_DIRS}
 )
 
-file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/src/*.cpp)
+file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${PROJECT_SOURCE_DIR}/src/*.cpp)
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_srcs})
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 

--- a/ros/src/crazyflie_ros/crazyflie_driver/CMakeLists.txt
+++ b/ros/src/crazyflie_ros/crazyflie_driver/CMakeLists.txt
@@ -90,6 +90,7 @@ add_dependencies(crazyflie_server
 ## Specify libraries to link a library or executable target against
 target_link_libraries(crazyflie_server
   ${catkin_LIBRARIES}
+  usb-1.0
 )
 
 ## Declare a cpp executable
@@ -103,6 +104,7 @@ add_dependencies(crazyflie_add
 
 target_link_libraries(crazyflie_add
   ${catkin_LIBRARIES}
+  usb-1.0
 )
 
 #############

--- a/ros/src/crazyflie_ros/crazyflie_tools/CMakeLists.txt
+++ b/ros/src/crazyflie_ros/crazyflie_tools/CMakeLists.txt
@@ -39,44 +39,66 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-## Declare a cpp executable
-add_executable(scan
-  src/scan.cpp
+## List of executable names to generate
+set(executables
+  scan
+  listParams
+  listLogVariables
+  reboot
+  ## add more as needed
 )
+# manually change depending on if there's unique dependencies to add to an individual executable
+set(HAS_INDEPENDENT_LIBRARIES FALSE)
+## add executables (loop through)
+foreach(executable ${executables})
+	add_executable(${executable} src/${executable}.cpp)
+	## Specify libraries to link a library or executable target against
+	target_link_libraries(${executable}
+	    ${catkin_LIBRARIES}
+	    ${Boost_LIBRARIES}
+	    usb-1.0
+	  )
+endforeach()
 
-## Specify libraries to link a library or executable target against
-target_link_libraries(scan
-  ${catkin_LIBRARIES}
-  ${Boost_LIBRARIES}
-)
+if(HAS_INDEPENDENT_LIBRARIES)
+  ## Declare a cpp executable
+  add_executable(scan
+    src/scan.cpp
+  )
 
-### listParams
-add_executable(listParams
-  src/listParams.cpp
-)
-target_link_libraries(listParams
-  ${catkin_LIBRARIES}
-  ${Boost_LIBRARIES}
-)
+  ## Specify libraries to link a library or executable target against
+  target_link_libraries(scan
+    ${catkin_LIBRARIES}
+    ${Boost_LIBRARIES}
+  )
 
-### listLogVariables
-add_executable(listLogVariables
-  src/listLogVariables.cpp
-)
-target_link_libraries(listLogVariables
-  ${catkin_LIBRARIES}
-  ${Boost_LIBRARIES}
-)
+  ### listParams
+  add_executable(listParams
+    src/listParams.cpp
+  )
+  target_link_libraries(listParams
+    ${catkin_LIBRARIES}
+    ${Boost_LIBRARIES}
+  )
 
-### reboot
-add_executable(reboot
-  src/reboot.cpp
-)
-target_link_libraries(reboot
-  ${catkin_LIBRARIES}
-  ${Boost_LIBRARIES}
-)
+  ### listLogVariables
+  add_executable(listLogVariables
+    src/listLogVariables.cpp
+  )
+  target_link_libraries(listLogVariables
+    ${catkin_LIBRARIES}
+    ${Boost_LIBRARIES}
+  )
 
+  ### reboot
+  add_executable(reboot
+    src/reboot.cpp
+  )
+  target_link_libraries(reboot
+    ${catkin_LIBRARIES}
+    ${Boost_LIBRARIES}
+  )
+endif()
 #############
 ## Install ##
 #############

--- a/ros/src/crazyflie_simulator/CMakeLists.txt
+++ b/ros/src/crazyflie_simulator/CMakeLists.txt
@@ -7,7 +7,7 @@ project(crazyflie_simulator)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 #endif()
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/crazyflie_simulator/modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/modules)
 message("Cmake module path: ${CMAKE_MODULE_PATH}")
 
 find_package(Eigen3 REQUIRED)
@@ -55,7 +55,7 @@ link_directories(
   ${EIGEN3_LIBRARY_DIRS}
 )
 
-file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/src/*.cpp)
+file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${PROJECT_SOURCE_DIR}/src/*.cpp)
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_srcs})
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 

--- a/ros/src/crazyflie_state_estimator/CMakeLists.txt
+++ b/ros/src/crazyflie_state_estimator/CMakeLists.txt
@@ -7,7 +7,7 @@ project(crazyflie_state_estimator)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 #endif()
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/crazyflie_state_estimator/modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/modules)
 message("Cmake module path: ${CMAKE_MODULE_PATH}")
 
 find_package(Eigen3 REQUIRED)
@@ -55,7 +55,7 @@ link_directories(
   ${EIGEN3_LIBRARY_DIRS}
 )
 
-file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/src/*.cpp)
+file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${PROJECT_SOURCE_DIR}/src/*.cpp)
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_srcs})
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
@@ -70,6 +70,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${EIGEN3_LIBRARIES}
+  usb-1.0
 )
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
@@ -98,6 +99,7 @@ foreach(executable ${${PROJECT_NAME}_execs})
     ${PROJECT_NAME}
     ${catkin_LIBRARIES}
     ${EIGEN3_LIBRARIES}
+    usb-1.0
   )
 endforeach()
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -115,5 +117,6 @@ if(CATKIN_ENABLE_TESTING)
     ${PROJECT_NAME}
     ${GTEST_LIBRARIES}
     ${EIGEN3_LIBRARIES}
+    usb-1.0
   )
 endif()

--- a/ros/src/crazyflie_takeoff/CMakeLists.txt
+++ b/ros/src/crazyflie_takeoff/CMakeLists.txt
@@ -7,7 +7,7 @@ project(crazyflie_takeoff)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 #endif()
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/crazyflie_takeoff/modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/modules)
 message("Cmake module path: ${CMAKE_MODULE_PATH}")
 
 find_package(Eigen3 REQUIRED)
@@ -55,7 +55,7 @@ link_directories(
   ${EIGEN3_LIBRARY_DIRS}
 )
 
-file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}/src/*.cpp)
+file(GLOB_RECURSE ${PROJECT_NAME}_srcs ${PROJECT_SOURCE_DIR}/src/*.cpp)
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_srcs})
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 


### PR DESCRIPTION
patch for certain files unable to find modules for usb, and searching for in incorrect directories for addlibrary() when running catkin_build from ~/catkin_ws instead of from the child directory of /crazyflie_clean/ros